### PR TITLE
add javacOptions to check jdk version when compile

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,7 @@ lazy val commonSettings =
     scalaVersion      := scala3_Version,
     doc / sources     := Seq(),
     javafmtOnCompile  := true,
+    javacOptions ++= Seq("-source", "21", "-encoding", "UTF-8"),
     scalacOptions ++= Seq(
       "-language:dynamics",
       "-explain",


### PR DESCRIPTION
currently we can only compile on Java21， add  this can help us to check our jdk version when compiled